### PR TITLE
Fix SwiftDependencyInjector dependency constraint

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "e3398b5b768448eebf78a4ece3c425229721b27992bceb5e09a338e23373b5b8",
+  "originHash" : "a4bd3cd2b6285ef7f012f4939d9d0606bdef9b6f7637195888557971dd0a68dd",
   "pins" : [
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-        "version" : "5.10.2"
+        "revision" : "3f99050e75bbc6fe71fc323adabb039756680016",
+        "version" : "5.11.1"
       }
     },
     {
@@ -15,8 +15,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/andresduke024/swift-dependency-injector",
       "state" : {
-        "revision" : "c13d93468689ac92ec1ac856ce94d73f242272cb",
-        "version" : "2.0.0"
+        "revision" : "33a017b64d8bde3891ac6baadc0364b829202616",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MELIStoreCore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/andresduke024/swift-dependency-injector", .upToNextMinor(from: "2.0.0")),
+        .package(url: "https://github.com/andresduke024/swift-dependency-injector", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.0"))
     ],
     targets: [


### PR DESCRIPTION
Enable upNextToMajor option for SwiftDependencyInjector dependency 